### PR TITLE
Gitignore and pyproject file for pip compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+*egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "IBS_for_xsuite"
+description = "Package to calculate IBS growth rates"
+version = "0.1.0"
+readme = "README.md"
+authors = [
+    { name = "Michalis Zampetakis", email = "michalis.zampetakis@cern.ch" }
+]
+dependencies = [
+    "numpy",
+    "matplotlib",
+    "pandas",
+    "scipy",
+]
+
+[tool.setuptools]
+py-modules = ['lib']
+
+
+
+


### PR DESCRIPTION
First step to make class compatible for python virtual environments for other projects. 
- `.gitignore` makes sure .pyc and .egg-info are not committed
- `pyproject.toml` allows IBS to be installed in virtual python environments with: `python -m pip install -e IBS_for_Xsuite`